### PR TITLE
feat: Replace each call to showView() in onKeyEvent

### DIFF
--- a/app/src/main/java/moe/chensi/volume/Service.kt
+++ b/app/src/main/java/moe/chensi/volume/Service.kt
@@ -56,6 +56,7 @@ import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import moe.chensi.volume.ui.theme.VolumeManagerTheme
+import moe.chensi.volume.volumemanager.PreferenceHelper
 import org.joor.Reflect
 import java.util.Objects
 
@@ -364,7 +365,10 @@ class Service : AccessibilityService() {
                             AudioManager.ADJUST_RAISE, AudioManager.USE_DEFAULT_STREAM_TYPE, 0
                         )
                     }
-                    showView()
+                    // Only show the overlay for physical volume buttons if the user allows it.
+                                        if (PreferenceHelper.isVolumeOverlayEnabled(this)) {
+                                                showView()
+                                            }
                 }
                 return true
             }
@@ -376,7 +380,10 @@ class Service : AccessibilityService() {
                             AudioManager.ADJUST_LOWER, AudioManager.USE_DEFAULT_STREAM_TYPE, 0
                         )
                     }
-                    showView()
+                    // Only show the overlay for physical volume buttons if the user allows it.
+                                        if (PreferenceHelper.isVolumeOverlayEnabled(this)) {
+                                                showView()
+                                            }
                 }
                 return true
             }

--- a/app/src/main/java/moe/chensi/volume/volumemanager/PreferenceHelper.kt
+++ b/app/src/main/java/moe/chensi/volume/volumemanager/PreferenceHelper.kt
@@ -1,0 +1,14 @@
+package moe.chensi.volume.volumemanager
+
+import android.content.Context
+
+object PreferenceHelper {
+    const val PREF_SHOW_VOLUME_OVERLAY = "pref_show_volume_overlay"
+
+    fun isVolumeOverlayEnabled(context: Context): Boolean {
+    // Default shared prefs name used by PreferenceFragmentCompat is usually: // "${context.packageName}_preferences"
+    val prefsName = "${context.packageName}_preferences"
+        val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+        return prefs.getBoolean(PREF_SHOW_VOLUME_OVERLAY, true)
+    }
+}

--- a/app/src/main/res/values/strings_volume_manager.xml
+++ b/app/src/main/res/values/strings_volume_manager.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="pref_show_volume_overlay_title">Show volume overlay</string>
+    <string name="pref_show_volume_overlay_summary">Show the overlay when pressing physical volume buttons</string>
+</resources>

--- a/app/src/main/res/xml/preferences_volume_manager.xml
+++ b/app/src/main/res/xml/preferences_volume_manager.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    >
+
+    <androidx.preference.SwitchPreferenceCompat
+        android:key="pref_show_volume_overlay"
+        android:title="@string/pref_show_volume_overlay_title"
+        android:summary="@string/pref_show_volume_overlay_summary"
+        android:defaultValue="true" />
+</PreferenceScreen>


### PR DESCRIPTION
Summary

Replace each call to showView() in onKeyEvent with a guard that reads preference.
(closes #3)

Motivation

Some users prefer the system volume change without an app-provided overlay.

